### PR TITLE
Added browser IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,19 @@
 npm init astro -- --template with-tailwindcss
 ```
 
+### Preview
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-tailwindcss)
 
+Quickly preview this example directly in your browser with StackBlitz.
+
+
 Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.
+
+### Develop
+
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/withastro/astro/tree/latest/examples/with-tailwindcss)
+
+Open this project in Codeanywhere's browser-based IDE for full development capabilities.
 
 For complete setup instructions, please see our [Styling Guide](https://docs.astro.build/guides/styling#-tailwind).


### PR DESCRIPTION
Hey,

I've added an "Open in Codeanywhere" badge to the README  as an optional environment setup shortcut. This could help first-time contributors by:
- Providing 1-click access to a pre-configured workspace
- Reducing local setup friction for quick explorations
- Maintaining existing setup instructions as the primary method

This is purely a suggestion based on what helped me get started faster. I'm happy to adjust the wording, remove it, or discuss alternative solutions if you feel this isn't a good fit for the project.

Would love to hear your thoughts!